### PR TITLE
Replace all whitespace characters

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -49,7 +49,7 @@ module.exports = {
         for (index in service.characteristics) {
             characteristic = service.characteristics[index];
 
-            const strippedName = characteristic.displayName.replace(' ', '');
+            const strippedName = characteristic.displayName.replace(/ /g, '');
             if (strippedName === name) {
                 return true;
             }
@@ -63,7 +63,7 @@ module.exports = {
         for (let index in service.characteristics) {
            characteristic = service.characteristics[index];
 
-           const strippedName = characteristic.displayName.replace(' ', '');
+           const strippedName = characteristic.displayName.replace(/ /g, '');
            if (strippedName === name) {
                return characteristic;
            }


### PR DESCRIPTION
replace(' ', '') only replaces the first occurence. Updated to regexp globally through the string.
Note this was breaking on the homebridge-http-humidity-sensor as it uses "CurrentRelativeHumidity" who's displayName is "Current Relative Humidity"